### PR TITLE
Added the ability to set the title of the data set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,4 +24,4 @@ Now in your view
     def all_users(request):
         headers = ['Name', 'City', 'Email']
         data = [(user.name, user.city, user.email) for user in users]
-        return {'data': data, 'headers': headers}
+        return {'data': data, 'headers': headers, 'title': 'Users'}

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,12 @@
 Pyramid_Tablib Changelog
 ==============================
 
+0.2 Mar 12, 2015
+---------------------
+
+- Added the ability to set the title of the data set.
+
+
 0.1 May 12, 2012
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1'
+version = '0.2'
 
 requires = [
     'tablib',

--- a/src/pyramid_tablib/renderer.py
+++ b/src/pyramid_tablib/renderer.py
@@ -14,7 +14,8 @@ class TabLibBaseRendererFactory(object):
             if ct == response.default_content_type:
                 response.content_type = self.content_type
         data = tablib.Dataset(*value.get('data', []),
-                headers=value.get('headers', []))
+                headers=value.get('headers', []),
+                title=value.get('title'))
         return data
 
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,7 +5,7 @@ mr.developer = 1.21
 zc.recipe.egg = 1.3.2
 
 # Required by:
-# pyramid-tablib==0.1
+# pyramid-tablib==0.2
 tablib = 0.9.11
 
 # Required by:


### PR DESCRIPTION
I noticed that generated files have the generic sheet title "Tablib Dataset". This change adds the ability to pass a `title` keyword argument in the data in order to change the title.

It also prepares a new version, 0.2, and adjusts setup.py. change log and README accordingly.

Please merge if you like and release v0.2 on PyPI.
